### PR TITLE
Prevent re-sending of commands

### DIFF
--- a/Broadlink RM Bridge Switch LAN
+++ b/Broadlink RM Bridge Switch LAN
@@ -43,15 +43,17 @@ def off() {
 }
  
 private put(toggle) {
-    def url1="xxx.xxx.x.x:xxxx"
-    def userpassascii= "username:password"
-    def userpass = "Basic " + userpassascii.encodeAsBase64().toString()
-    def toReplace = device.displayName
-	def replaced = toReplace.replaceAll(' ', '%20')
- 	def hubaction = new physicalgraph.device.HubAction(
-				method: "GET",
-               path: "/code/$replaced%20$toggle",
-               headers: [HOST: "${url1}", AUTHORIZATION: "${userpass}"],
+	if(state.currentState == null || state.currentState != toggle){
+    		def url1="xxx.xxx.x.x:xxxx"
+    		def userpassascii= "username:password"
+    		def userpass = "Basic " + userpassascii.encodeAsBase64().toString()
+    		def toReplace = device.displayName
+		def replaced = toReplace.replaceAll(' ', '%20')
+ 		def hubaction = new physicalgraph.device.HubAction(
+			method: "GET",
+               		path: "/code/$replaced%20$toggle",
+               		headers: [HOST: "${url1}", AUTHORIZATION: "${userpass}"],
                )
-   			return hubaction
+   		return hubaction
+   	}
    }


### PR DESCRIPTION
Currently, the device handler will send the IR codes to the RM even if the same code has already been issued.  For most devices this may not be a problem, but for devices that respond with confirmation of the code (i.e. an air conditioner beep), this can get annoying if coupled with a smart app that keeps sending "on" commands.

The code above stores the "on/off" state of the device in the smartthings state store and checks if it is in the current state or not before issuing the IR code.
